### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Code of Conduct
+
+## Our Pledge
+We pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity, level of experience, nationality, personal appearance, race, religion, or sexual identity.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Unacceptable behavior includes:
+- Use of sexualized language or imagery
+- Trolling, insulting or derogatory comments
+- Public or private harassment
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting the repository maintainers.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).


### PR DESCRIPTION
### Summary
Add `CODE_OF_CONDUCT.md` to define expected community behavior.

### Details
- Based on Contributor Covenant v2.1
- Includes examples of acceptable/unacceptable behavior
- Explains how to report violations

Closes #3 